### PR TITLE
Add dependencies to setup.py. Warning on sharedarray.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ if '--cuda' in sys.argv:
 install_requires = [
     'numpy>=1.7.0',
     'scipy>=0.12.0',
+    'matplotlib',
+    'h5py',
+    'scikit-image',
+    'zipp',
+    'six',
 ]
 
 
@@ -290,4 +295,3 @@ else:
 
 
 
-    


### PR DESCRIPTION
Added some dependencies needed to execute ssc-pimega/c/example/python/generate.py

A caveat: i should have also added sharedarray module, but as per open issue: https://github.com/andersbll/cudarray/issues/25 it causes fatal errors in installation, so for now manual installation is still needed.